### PR TITLE
Update build_check_mk_aarch64.sh to 1.6.0p20

### DIFF
--- a/build_check_mk_aarch64.sh
+++ b/build_check_mk_aarch64.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.6.0p19"
+VERSION="1.6.0p20"
 DEB_FULLNAME="check_mk_server for Ubuntu 20.04 on RPI4"
 DEB_EMAIL="your@email.foo"
 


### PR DESCRIPTION
Build tested on Ubuntu 20.04  aarch64 RPi 4.